### PR TITLE
run() refactorings

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -29,3 +29,5 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+/.idea

--- a/.npmignore
+++ b/.npmignore
@@ -30,4 +30,4 @@
 /bower.json.ember-try
 /package.json.ember-try
 
-/.idea
+/.idea/

--- a/addon/decorator.ts
+++ b/addon/decorator.ts
@@ -1,5 +1,6 @@
 import { assert } from '@ember/debug';
 import { getOwner } from '@ember/application';
+import LoadingService from 'ember-loading/services/loading';
 
 const loading: MethodDecorator = (desc: any) => {
   assert('The @loading decorator must be applied to methods', desc && desc.kind === 'method');
@@ -10,19 +11,14 @@ const loading: MethodDecorator = (desc: any) => {
     ...desc,
     descriptor: {
       ...desc.descriptor,
-      async value() {
+      value() {
 
         let owner = getOwner(this);
         assert('The target of the @loading decorator must have an owner.', !!owner);
 
-        let service = owner.lookup('service:loading');
+        let service: LoadingService = owner.lookup('service:loading');
 
-        try {
-          service.start();
-          return await orig.apply(this, arguments);
-        } finally {
-          service.stop();
-        }
+        return service.run(this, orig, ...arguments);
       }
     }
   };

--- a/addon/services/loading.ts
+++ b/addon/services/loading.ts
@@ -80,23 +80,29 @@ export default class LoadingService extends Service {
     this.router.off('routeDidChange', this._routeDidChange);
   }
 
-  run<T, P1, P2, P3, P4, P5, P6, R>(target: T, fn: ((p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) => R) | keyof T, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6): Promise<R>;
-  run<T, P1, P2, P3, P4, P5, R>(target: T, fn: ((p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => R) | keyof T, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5): Promise<R>;
-  run<T, P1, P2, P3, P4, R>(target: T, fn: ((p1: P1, p2: P2, p3: P3, p4: P4) => R) | keyof T, p1: P1, p2: P2, p3: P3, p4: P4): Promise<R>;
-  run<T, P1, P2, P3, R>(target: T, fn: ((p1: P1, p2: P2, p3: P3) => R) | keyof T, p1: P1, p2: P2, p3: P3): Promise<R>;
-  run<T, P1, P2, R>(target: T, fn: ((p1: P1, p2: P2) => R) | keyof T, p1: P1, p2: P2): Promise<R>;
-  run<T, P1, R>(target: T, fn: ((p1: P1) => R) | keyof T, p1: P1): Promise<R>;
-  run<T, R>(target: T, fn: (() => R) | keyof T): Promise<R>
-  run<P1, P2, P3, P4, P5, P6, R>(fn: (p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) => R, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6): Promise<R>;
-  run<P1, P2, P3, P4, P5, R>(fn: (p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => R, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5): Promise<R>;
-  run<P1, P2, P3, P4, R>(fn: (p1: P1, p2: P2, p3: P3, p4: P4) => R, p1: P1, p2: P2, p3: P3, p4: P4): Promise<R>;
-  run<P1, P2, P3, R>(fn: (p1: P1, p2: P2, p3: P3) => R, p1: P1, p2: P2, p3: P3): Promise<R>;
-  run<P1, P2, R>(fn: (p1: P1, p2: P2) => R, p1: P1, p2: P2): Promise<R>;
-  run<P1, R>(fn: (p1: P1) => R, p1: P1): Promise<R>;
-  run<R>(fn: () => R): Promise<R>;
-  async run() {
+  // @todo Revisit this stronger typing when https://github.com/typed-ember/ember-cli-typescript/issues/590 is resolved
+  //
+  // run<T, P1, P2, P3, P4, P5, P6, R>(target: T, fn: ((p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) => R) | keyof T, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6): Promise<R>;
+  // run<T, P1, P2, P3, P4, P5, R>(target: T, fn: ((p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => R) | keyof T, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5): Promise<R>;
+  // run<T, P1, P2, P3, P4, R>(target: T, fn: ((p1: P1, p2: P2, p3: P3, p4: P4) => R) | keyof T, p1: P1, p2: P2, p3: P3, p4: P4): Promise<R>;
+  // run<T, P1, P2, P3, R>(target: T, fn: ((p1: P1, p2: P2, p3: P3) => R) | keyof T, p1: P1, p2: P2, p3: P3): Promise<R>;
+  // run<T, P1, P2, R>(target: T, fn: ((p1: P1, p2: P2) => R) | keyof T, p1: P1, p2: P2): Promise<R>;
+  // run<T, P1, R>(target: T, fn: ((p1: P1) => R) | keyof T, p1: P1): Promise<R>;
+  // run<T, R>(target: T, fn: (() => R) | keyof T): Promise<R>
+  // run<P1, P2, P3, P4, P5, P6, R>(fn: (p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) => R, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6): Promise<R>;
+  // run<P1, P2, P3, P4, P5, R>(fn: (p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => R, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5): Promise<R>;
+  // run<P1, P2, P3, P4, R>(fn: (p1: P1, p2: P2, p3: P3, p4: P4) => R, p1: P1, p2: P2, p3: P3, p4: P4): Promise<R>;
+  // run<P1, P2, P3, R>(fn: (p1: P1, p2: P2, p3: P3) => R, p1: P1, p2: P2, p3: P3): Promise<R>;
+  // run<P1, P2, R>(fn: (p1: P1, p2: P2) => R, p1: P1, p2: P2): Promise<R>;
+  // run<P1, R>(fn: (p1: P1) => R, p1: P1): Promise<R>;
+  // run<R>(fn: () => R): Promise<R>;
+  // run<T, R>(target: T, fn: ((...args: any[]) => R) | keyof T, ...args: any[]): Promise<R>;
+  // run<T, R>(target: T, fn: (() => R) | keyof T): Promise<R>;
+  // run<R>(fn: (...args: any[]) => R, ...args: any[]): Promise<R>;
+  // run<R>(fn: () => R): Promise<R>;
+  async run(...args: any[]) {
     // @ts-ignore
-    let result = await this._runJob.perform(...arguments);
+    let result = await this._runJob.perform(...args);
 
     // don't await for delay
     // @ts-ignore

--- a/addon/services/loading.ts
+++ b/addon/services/loading.ts
@@ -5,6 +5,49 @@ import { task, restartableTask } from 'ember-concurrency-decorators';
 import { inject as service } from '@ember-decorators/service';
 import RouterService from '@ember/routing/router-service';
 
+type ParseArgsValue = [any, Function, any[] | undefined];
+
+function parseArgs(...args: any[]): ParseArgsValue;
+function parseArgs(): ParseArgsValue {
+  let length = arguments.length;
+
+  let args;
+  let method;
+  let target;
+
+  if (length === 0) {
+  } else if (length === 1) {
+    target = null;
+    method = arguments[0];
+  } else {
+    let argsIndex = 2;
+    let methodOrTarget = arguments[0];
+    let methodOrArgs = arguments[1];
+    let type = typeof methodOrArgs;
+    if (type === 'function') {
+      target = methodOrTarget;
+      method = methodOrArgs;
+    } else if (methodOrTarget !== null && type === 'string' && methodOrArgs in methodOrTarget) {
+      target = methodOrTarget;
+      method = target[methodOrArgs];
+    } else if (typeof methodOrTarget === 'function') {
+      argsIndex = 1;
+      target = null;
+      method = methodOrTarget;
+    }
+
+    if (length > argsIndex) {
+      let len = length - argsIndex;
+      args = new Array(len);
+      for (let i = 0; i < len; i++) {
+        args[i] = arguments[i + argsIndex];
+      }
+    }
+  }
+
+  return [target, method, args];
+}
+
 export default class LoadingService extends Service {
 
   @service
@@ -15,7 +58,7 @@ export default class LoadingService extends Service {
    */
   counter = 0;
 
-  loadingDelay = 20;
+  loadingDelay = 0;
 
   @or('hasCounter', '_runJob.isRunning', 'routerTransitionsPending')
   isLoading!: boolean;
@@ -65,18 +108,28 @@ export default class LoadingService extends Service {
     this.decrementProperty('counter');
   }
 
-  async runJob(job: () => any, delay = this.loadingDelay) {
+  // async run<T extends Function>(target: any, method: T): Promise<T>;
+  // async run<T extends Function>(target: any, method: T, ...args): Promise<T>;
+
+
+  // async run<T extends Function, U >(target: Function | any | null, method?: T | [], ...args: any[]): Promise<T>;
+  // async run(target: any | null | undefined, method?: Function, ...args: any[]): Promise<any>;
+  // async run<T extends (...args: any[]) => R, R>(method: T): Promise<R>;
+  async run() {
     // @ts-ignore
-    await this._runJob.perform(job);
+    let result = await this._runJob.perform(...arguments);
 
     // don't await for delay
     // @ts-ignore
-    this.delayTask.perform(delay);
+    this.delayTask.perform(this.loadingDelay);
+
+    return result;
   }
 
   @task
-  * _runJob(job: () => any) {
-    yield job();
+  * _runJob() {
+    let [target, method, args] = parseArgs(...arguments);
+    return yield method.apply(target, args);
   }
 
   @restartableTask

--- a/addon/services/loading.ts
+++ b/addon/services/loading.ts
@@ -15,11 +15,10 @@ function parseArgs(): ParseArgsValue {
   let method;
   let target;
 
-  if (length === 0) {
-  } else if (length === 1) {
+  if (length === 1) {
     target = null;
     method = arguments[0];
-  } else {
+  } else if (length > 1) {
     let argsIndex = 2;
     let methodOrTarget = arguments[0];
     let methodOrArgs = arguments[1];

--- a/addon/services/loading.ts
+++ b/addon/services/loading.ts
@@ -53,21 +53,13 @@ export default class LoadingService extends Service {
   @service
   router!: RouterService;
 
-  /**
-   * @private
-   */
-  counter = 0;
-
   loadingDelay = 0;
 
-  @or('hasCounter', '_runJob.isRunning', 'routerTransitionsPending')
+  @or('_runJob.isRunning', 'routerTransitionsPending')
   isLoading!: boolean;
 
   @or('isLoading', 'delayTask.isRunning')
   showLoading!: boolean;
-
-  @gt('counter', 0)
-  hasCounter!: boolean;
 
   routerTransitionsPending = false;
 
@@ -86,26 +78,6 @@ export default class LoadingService extends Service {
 
     this.router.off('routeWillChange', this._routeWillChange);
     this.router.off('routeDidChange', this._routeDidChange);
-  }
-
-  /**
-   * Call this when starting a load action
-   *
-   * @method start
-   * @public
-   */
-  start() {
-    this.incrementProperty('counter');
-  }
-
-  /**
-   * Call this when loading action has finished
-   *
-   * @method stop
-   * @public
-   */
-  stop() {
-    this.decrementProperty('counter');
   }
 
   // async run<T extends Function>(target: any, method: T): Promise<T>;

--- a/addon/services/loading.ts
+++ b/addon/services/loading.ts
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
-import { gt, or } from '@ember-decorators/object/computed';
+import { or } from '@ember-decorators/object/computed';
 import { timeout } from 'ember-concurrency';
-import { task, restartableTask } from 'ember-concurrency-decorators';
+import { restartableTask, task } from 'ember-concurrency-decorators';
 import { inject as service } from '@ember-decorators/service';
 import RouterService from '@ember/routing/router-service';
 
@@ -80,13 +80,20 @@ export default class LoadingService extends Service {
     this.router.off('routeDidChange', this._routeDidChange);
   }
 
-  // async run<T extends Function>(target: any, method: T): Promise<T>;
-  // async run<T extends Function>(target: any, method: T, ...args): Promise<T>;
-
-
-  // async run<T extends Function, U >(target: Function | any | null, method?: T | [], ...args: any[]): Promise<T>;
-  // async run(target: any | null | undefined, method?: Function, ...args: any[]): Promise<any>;
-  // async run<T extends (...args: any[]) => R, R>(method: T): Promise<R>;
+  run<T, P1, P2, P3, P4, P5, P6, R>(target: T, fn: ((p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) => R) | keyof T, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6): Promise<R>;
+  run<T, P1, P2, P3, P4, P5, R>(target: T, fn: ((p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => R) | keyof T, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5): Promise<R>;
+  run<T, P1, P2, P3, P4, R>(target: T, fn: ((p1: P1, p2: P2, p3: P3, p4: P4) => R) | keyof T, p1: P1, p2: P2, p3: P3, p4: P4): Promise<R>;
+  run<T, P1, P2, P3, R>(target: T, fn: ((p1: P1, p2: P2, p3: P3) => R) | keyof T, p1: P1, p2: P2, p3: P3): Promise<R>;
+  run<T, P1, P2, R>(target: T, fn: ((p1: P1, p2: P2) => R) | keyof T, p1: P1, p2: P2): Promise<R>;
+  run<T, P1, R>(target: T, fn: ((p1: P1) => R) | keyof T, p1: P1): Promise<R>;
+  run<T, R>(target: T, fn: (() => R) | keyof T): Promise<R>
+  run<P1, P2, P3, P4, P5, P6, R>(fn: (p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) => R, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6): Promise<R>;
+  run<P1, P2, P3, P4, P5, R>(fn: (p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => R, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5): Promise<R>;
+  run<P1, P2, P3, P4, R>(fn: (p1: P1, p2: P2, p3: P3, p4: P4) => R, p1: P1, p2: P2, p3: P3, p4: P4): Promise<R>;
+  run<P1, P2, P3, R>(fn: (p1: P1, p2: P2, p3: P3) => R, p1: P1, p2: P2, p3: P3): Promise<R>;
+  run<P1, P2, R>(fn: (p1: P1, p2: P2) => R, p1: P1, p2: P2): Promise<R>;
+  run<P1, R>(fn: (p1: P1) => R, p1: P1): Promise<R>;
+  run<R>(fn: () => R): Promise<R>;
   async run() {
     // @ts-ignore
     let result = await this._runJob.perform(...arguments);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@ember-decorators/babel-transforms": "^3.1.0",
     "ember-concurrency": "^0.8.26",
     "ember-concurrency-decorators": "^0.5.3",
-    "ember-decorators": "^5.1.2",
+    "ember-decorators": "^5.1.4",
     "ember-cli-typescript": "^2.0.0-rc.2",
     "ember-cli-htmlbars": "^3.0.0"
   },

--- a/tests/integration/components/while-loading-test.ts
+++ b/tests/integration/components/while-loading-test.ts
@@ -3,12 +3,14 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import LoadingService from '../../../addon/services/loading';
+import { defer } from 'rsvp';
 
 module('Integration | Component | while-loading', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders while loading', async function(assert) {
     let service: LoadingService = this.owner.lookup('service:loading');
+    let deferred = defer();
 
     await render(hbs`
       {{#while-loading}}
@@ -18,11 +20,11 @@ module('Integration | Component | while-loading', function(hooks) {
 
     assert.dom('#loading-indicator').doesNotExist();
 
-    service.start();
+    service.run(() => deferred.promise);
     await settled();
     assert.dom('#loading-indicator').exists();
 
-    service.stop();
+    deferred.resolve();
     await settled();
     assert.dom('#loading-indicator').doesNotExist();
   });

--- a/tests/unit/decorators/loading-test.ts
+++ b/tests/unit/decorators/loading-test.ts
@@ -4,23 +4,23 @@ import EmberObject from '@ember/object';
 import loading from 'ember-loading/decorator';
 import RSVP, { defer } from 'rsvp';
 
-class Test extends EmberObject {
-  defer?: RSVP.Deferred<void>;
-
-  @loading
-  asyncSomething() {
-    this.defer = defer();
-    return this.defer.promise;
-  }
-}
-
 module('Unit | Decorator | loading', function(hooks) {
   setupTest(hooks);
 
   test('it sets loading state', async function(assert) {
 
+    class Test extends EmberObject {
+      defer?: RSVP.Deferred<void>;
+
+      @loading
+      asyncSomething() {
+        this.defer = defer();
+        return this.defer.promise;
+      }
+    }
+
     let service = this.owner.lookup('service:loading');
-    let obj = new Test(this.owner.ownerInjection());
+    let obj = Test.create(this.owner.ownerInjection());
 
     assert.notOk(service.get('isLoading'));
 
@@ -30,6 +30,29 @@ module('Unit | Decorator | loading', function(hooks) {
     obj.defer!.resolve();
     await promise;
     assert.notOk(service.get('isLoading'));
+  });
+
+  test('it passes args and return value', async function(assert) {
+    assert.expect(2);
+
+    class Test extends EmberObject {
+      defer?: RSVP.Deferred<number>;
+
+      @loading
+      asyncSomething(arg: string) {
+        this.defer = defer();
+        assert.equal(arg, 'foo');
+        return this.defer.promise;
+      }
+    }
+
+    let obj = Test.create(this.owner.ownerInjection());
+    let promise = obj.asyncSomething('foo');
+
+    obj.defer!.resolve(1);
+    let result = await promise;
+
+    assert.equal(result, 1);
   });
 });
 

--- a/tests/unit/services/loading-test.ts
+++ b/tests/unit/services/loading-test.ts
@@ -67,7 +67,7 @@ module('Unit | Service | loading', function(hooks) {
 
   test('passes args', async function(assert) {
     assert.expect(2);
-    let job = (a: number, b: string) => {
+    let job = function(a: number, b: string) {
       assert.equal(a, 2);
       assert.equal(b, 'foo');
     };
@@ -78,8 +78,8 @@ module('Unit | Service | loading', function(hooks) {
 
   // used to test the typing
   test('passes many args', async function(assert) {
-    assert.expect(2);
-    let job = () => {
+    assert.expect(1);
+    let job = function() {
       assert.equal(arguments.length, 6);
     };
 
@@ -135,9 +135,7 @@ module('Unit | Service | loading', function(hooks) {
     let foo = new Foo;
 
     let service: LoadingService = this.owner.lookup('service:loading');
-    let result = await service.run(foo, 'job');
-    result = await service.run(foo, 'job', 1);
-    result = await service.run(foo, 'job', '', 'foo');
+    let result = await service.run(foo, 'job', 1, 'foo');
 
     assert.equal(result, 'foo');
     assert.equal(context, foo);

--- a/tests/unit/services/loading-test.ts
+++ b/tests/unit/services/loading-test.ts
@@ -29,7 +29,38 @@ module('Unit | Service | loading', function(hooks) {
     assert.notOk(service.get('isLoading'));
     assert.ok(service.get('showLoading'));
 
-    await timeout(5);
+    await timeout(1);
+    assert.notOk(service.get('isLoading'));
+    assert.notOk(service.get('showLoading'));
+  });
+
+  test('waits for all async jobs', async function(assert) {
+    let deferred1 = defer();
+    let deferred2 = defer();
+
+    let service: LoadingService = this.owner.lookup('service:loading');
+    assert.notOk(service.get('isLoading'));
+    assert.notOk(service.get('showLoading'));
+
+    let promise1 = service.run(() => deferred1.promise);
+    assert.ok(service.get('isLoading'));
+    assert.ok(service.get('showLoading'));
+
+    let promise2 = service.run(() => deferred2.promise);
+    assert.ok(service.get('isLoading'));
+    assert.ok(service.get('showLoading'));
+
+    deferred1.resolve();
+    await promise1;
+    assert.ok(service.get('isLoading'));
+    assert.ok(service.get('showLoading'));
+
+    deferred2.resolve();
+    await promise2;
+    assert.notOk(service.get('isLoading'));
+    assert.ok(service.get('showLoading'));
+
+    await timeout(1);
     assert.notOk(service.get('isLoading'));
     assert.notOk(service.get('showLoading'));
   });

--- a/tests/unit/services/loading-test.ts
+++ b/tests/unit/services/loading-test.ts
@@ -1,12 +1,14 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { timeout } from 'ember-concurrency';
+import LoadingService from 'ember-loading/services/loading';
+import RSVP, { defer } from 'rsvp';
 
 module('Unit | Service | loading', function(hooks) {
   setupTest(hooks);
 
   test('switching on/off is behaving properly', function(assert) {
-    let service = this.owner.lookup('service:loading');
+    let service: LoadingService = this.owner.lookup('service:loading');
     assert.notOk(service.get('isLoading'));
     service.start();
     assert.ok(service.get('isLoading'));
@@ -15,7 +17,7 @@ module('Unit | Service | loading', function(hooks) {
   });
 
   test('stays on when multiple requests are requested and switch off while all requests are done', function(assert) {
-    let service = this.owner.lookup('service:loading');
+    let service: LoadingService = this.owner.lookup('service:loading');
     assert.notOk(service.get('isLoading'));
     service.start();
     service.start();
@@ -26,17 +28,24 @@ module('Unit | Service | loading', function(hooks) {
     assert.notOk(service.get('isLoading'));
   });
 
-  test('can run jobs', async function(assert) {
-    let service = this.owner.lookup('service:loading');
+  test('can run async jobs', async function(assert) {
+    let deferred = defer();
+    let called = false;
+    let job = () => {
+      called = true;
+      return deferred.promise;
+    };
+
+    let service: LoadingService = this.owner.lookup('service:loading');
     assert.notOk(service.get('isLoading'));
     assert.notOk(service.get('showLoading'));
 
-    let job = () => timeout(10);
-
-    let promise = service.runJob(job, 5);
+    let promise = service.run(job);
+    assert.ok(called, 'job has been called');
     assert.ok(service.get('isLoading'));
     assert.ok(service.get('showLoading'));
 
+    deferred.resolve();
     await promise;
     assert.notOk(service.get('isLoading'));
     assert.ok(service.get('showLoading'));
@@ -45,5 +54,60 @@ module('Unit | Service | loading', function(hooks) {
     assert.notOk(service.get('isLoading'));
     assert.notOk(service.get('showLoading'));
   });
+
+  test('passes args', async function(assert) {
+    assert.expect(2);
+    let job = (a: number, b: string) => {
+      assert.equal(a, 2);
+      assert.equal(b, 'foo');
+    };
+
+    let service: LoadingService = this.owner.lookup('service:loading');
+    await service.run(job, 2, 'foo');
+  });
+
+  test('context', async function(assert) {
+    assert.expect(1);
+    let context = {};
+    let job = function(this: any) {
+      assert.equal(this, context);
+    };
+
+    let service: LoadingService = this.owner.lookup('service:loading');
+    await service.run(context, job);
+  });
+
+  test('return value', async function(assert) {
+    let deferred = defer();
+    let job = () => deferred.promise;
+
+    let service: LoadingService = this.owner.lookup('service:loading');
+    let promise = service.run(job);
+    deferred.resolve('foo');
+    let result = await promise;
+    assert.equal(result, 'foo');
+  });
+
+  test('method lookup', async function(assert) {
+    assert.expect(4);
+    let context;
+
+    class Foo {
+      job(arg1: number, arg2: string) {
+        context = this;
+        assert.equal(arg1, 1);
+        assert.equal(arg2, 'foo');
+        return 'foo';
+      }
+    }
+    let foo = new Foo;
+
+    let service: LoadingService = this.owner.lookup('service:loading');
+    let result = await service.run(foo, 'job', 1, 'foo');
+
+    assert.equal(result, 'foo');
+    assert.equal(context, foo);
+  });
+
 });
 

--- a/tests/unit/services/loading-test.ts
+++ b/tests/unit/services/loading-test.ts
@@ -2,31 +2,10 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { timeout } from 'ember-concurrency';
 import LoadingService from 'ember-loading/services/loading';
-import RSVP, { defer } from 'rsvp';
+import { defer } from 'rsvp';
 
 module('Unit | Service | loading', function(hooks) {
   setupTest(hooks);
-
-  test('switching on/off is behaving properly', function(assert) {
-    let service: LoadingService = this.owner.lookup('service:loading');
-    assert.notOk(service.get('isLoading'));
-    service.start();
-    assert.ok(service.get('isLoading'));
-    service.stop();
-    assert.notOk(service.get('isLoading'));
-  });
-
-  test('stays on when multiple requests are requested and switch off while all requests are done', function(assert) {
-    let service: LoadingService = this.owner.lookup('service:loading');
-    assert.notOk(service.get('isLoading'));
-    service.start();
-    service.start();
-    assert.ok(service.get('isLoading'));
-    service.stop();
-    assert.ok(service.get('isLoading'));
-    service.stop();
-    assert.notOk(service.get('isLoading'));
-  });
 
   test('can run async jobs', async function(assert) {
     let deferred = defer();

--- a/tests/unit/services/loading-test.ts
+++ b/tests/unit/services/loading-test.ts
@@ -9,9 +9,9 @@ module('Unit | Service | loading', function(hooks) {
 
   test('can run async jobs', async function(assert) {
     let deferred = defer();
-    let called = false;
+    let called = 0;
     let job = () => {
-      called = true;
+      called++;
       return deferred.promise;
     };
 
@@ -20,7 +20,7 @@ module('Unit | Service | loading', function(hooks) {
     assert.notOk(service.get('showLoading'));
 
     let promise = service.run(job);
-    assert.ok(called, 'job has been called');
+    assert.equal(called, 1, 'job has been called');
     assert.ok(service.get('isLoading'));
     assert.ok(service.get('showLoading'));
 

--- a/tests/unit/services/loading-test.ts
+++ b/tests/unit/services/loading-test.ts
@@ -76,6 +76,17 @@ module('Unit | Service | loading', function(hooks) {
     await service.run(job, 2, 'foo');
   });
 
+  // used to test the typing
+  test('passes many args', async function(assert) {
+    assert.expect(2);
+    let job = () => {
+      assert.equal(arguments.length, 6);
+    };
+
+    let service: LoadingService = this.owner.lookup('service:loading');
+    await service.run(job, 2, 'foo', 2, 'foo', 2, 'foo');
+  });
+
   test('context', async function(assert) {
     assert.expect(1);
     let context = {};
@@ -87,14 +98,25 @@ module('Unit | Service | loading', function(hooks) {
     await service.run(context, job);
   });
 
-  test('return value', async function(assert) {
-    let deferred = defer();
-    let job = () => deferred.promise;
+  test('context with args', async function(assert) {
+    assert.expect(3);
+    let context = {};
+    let job = function(this: any, a: number, b: string) {
+      assert.equal(this, context);
+      assert.equal(a, 2);
+      assert.equal(b, 'foo');
+    };
+
+    let service: LoadingService = this.owner.lookup('service:loading');
+    await service.run(context, job, 2, 'foo');
+  });
+
+  test('return promise value', async function(assert) {
+    let job = async () => 'foo';
 
     let service: LoadingService = this.owner.lookup('service:loading');
     let promise = service.run(job);
-    deferred.resolve('foo');
-    let result = await promise;
+    let result: string = await promise;
     assert.equal(result, 'foo');
   });
 
@@ -113,7 +135,9 @@ module('Unit | Service | loading', function(hooks) {
     let foo = new Foo;
 
     let service: LoadingService = this.owner.lookup('service:loading');
-    let result = await service.run(foo, 'job', 1, 'foo');
+    let result = await service.run(foo, 'job');
+    result = await service.run(foo, 'job', 1);
+    result = await service.run(foo, 'job', '', 'foo');
 
     assert.equal(result, 'foo');
     assert.equal(context, foo);

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,44 +677,64 @@
     ember-cli-babel-plugin-helpers "^1.0.0"
     ember-cli-version-checker "^2.1.0"
 
-"@ember-decorators/component@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/component/-/component-5.1.2.tgz#67ef09b083f7e94f0669e726b66a25cfdb44de4d"
+"@ember-decorators/component@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/component/-/component-5.1.4.tgz#bb1fba00fc025366cf1f60252b76c07ac8b6fbbe"
+  integrity sha512-Pe4D/nN0vpRPq9tkeNuKVtWBjTorcqjwlgRHMiiLvzFTVA4LYATyLtRNRGJXNgW1RFn98kHUy7jLyN/EhYw6qg==
   dependencies:
-    "@ember-decorators/utils" "^5.1.2"
+    "@ember-decorators/utils" "^5.1.4"
     ember-cli-babel "^7.1.3"
 
-"@ember-decorators/controller@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/controller/-/controller-5.1.2.tgz#afb45a3ec4e9e4abc9bd4ab17ba53693bf21b5a2"
+"@ember-decorators/controller@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/controller/-/controller-5.1.4.tgz#8dd322bccd81a97892979bd44c92c9aa9d4fe272"
+  integrity sha512-+NSxQCWM3I7VBCNRSR1W8JcGUNxS01XZaAP1DgQJO9NONNzHgskS3F/7NtZJxGc0Dao9mMiQ5XRPuVIsTVekQA==
   dependencies:
-    "@ember-decorators/utils" "^5.1.2"
+    "@ember-decorators/utils" "^5.1.4"
     ember-cli-babel "^7.1.3"
+    ember-compatibility-helpers "^1.1.2"
 
-"@ember-decorators/data@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/data/-/data-5.1.2.tgz#ae77cdf245284be63619190bebf81bee39af5b88"
+"@ember-decorators/data@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/data/-/data-5.1.4.tgz#08e0fefe83ce855bcc5837bd8ea7feb5ecefb2ac"
+  integrity sha512-VKADr3MF6TobFgivKM8BaLIoFHuxgqR9Jtr5vY84TVEgUsTpbkx7xTYJRNWECzmY9hOJ7myqL/KH3mA+vrq3fw==
   dependencies:
-    "@ember-decorators/utils" "^5.1.2"
+    "@ember-decorators/utils" "^5.1.4"
     ember-cli-babel "^7.1.3"
+    ember-compatibility-helpers "^1.1.2"
 
-"@ember-decorators/object@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/object/-/object-5.1.2.tgz#575ad09bf891b283b0ccdad1ff58154f41a855a5"
+"@ember-decorators/object@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/object/-/object-5.1.4.tgz#41ea33864cf742b42e47b6d13b6edf8baa5e7b28"
+  integrity sha512-r3zFXUp8yuHHq+7XKLFvq+xAAap4JK9i8gDjuyu1eW8sxeAszn/3sK5b+l1LT9wSC9aALhYhAIBeNRjcan8APA==
   dependencies:
-    "@ember-decorators/utils" "^5.1.2"
+    "@ember-decorators/utils" "^5.1.4"
     ember-cli-babel "^7.1.3"
+    ember-compatibility-helpers "^1.1.2"
 
-"@ember-decorators/service@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/service/-/service-5.1.2.tgz#b547b2fbb4a5a2fd30cdc83fcd1345c52458099b"
+"@ember-decorators/service@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/service/-/service-5.1.4.tgz#a42525245eff3fc327845bdbca4bb38f9e3a6663"
+  integrity sha512-7Lmh8DDe21BhDi5ZKGHHmijl+QwTFBeVLeD6UqDlO8XBwPstPIyVUPXdpSSvqjSxaXx8gj1vke356JAEGxiN9g==
   dependencies:
-    "@ember-decorators/utils" "^5.1.2"
+    "@ember-decorators/utils" "^5.1.4"
     ember-cli-babel "^7.1.3"
+    ember-compatibility-helpers "^1.1.2"
 
-"@ember-decorators/utils@^3.1.2 || ^4.0.0 || ^5.0.0", "@ember-decorators/utils@^5.1.2":
+"@ember-decorators/utils@^3.1.2 || ^4.0.0 || ^5.0.0":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-5.1.2.tgz#23ff1561ae6ecde14799d5df2a985fa134ca5269"
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-babel "^7.1.3"
+    ember-cli-version-checker "^3.0.0"
+    ember-compatibility-helpers "^1.1.2"
+    semver "^5.6.0"
+
+"@ember-decorators/utils@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-5.1.4.tgz#e8a18e614b3bd282c548803fd5e94d49d8fbaeee"
+  integrity sha512-wWJwhVIG1xwY0PbyWx7GHIkEvqDejzJ6trHtHSsTjBhhLbBtQqJN3DCHe4IltCyvizhzusRiFrZJB1g+eWiXCA==
   dependencies:
     babel-plugin-debug-macros "^0.2.0"
     ember-cli-babel "^7.1.3"
@@ -3253,15 +3273,16 @@ ember-concurrency@^0.8.26:
     ember-cli-babel "^6.8.2"
     ember-maybe-import-regenerator "^0.1.5"
 
-ember-decorators@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/ember-decorators/-/ember-decorators-5.1.2.tgz#e4fc1b029a03e3f09fb6ae24ac4e6cf4177e4378"
+ember-decorators@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ember-decorators/-/ember-decorators-5.1.4.tgz#d574fbfab85bb3938f1dd18f5a0b1569ea0eb4cb"
+  integrity sha512-0qpN65A4lr0NBkkdWUJGn6VlaA6WoFXAUrgWruF53UK3tszb0nVK/EPN2zRU06I/7WgroI69VywdVPe3TRQ/iw==
   dependencies:
-    "@ember-decorators/component" "^5.1.2"
-    "@ember-decorators/controller" "^5.1.2"
-    "@ember-decorators/data" "^5.1.2"
-    "@ember-decorators/object" "^5.1.2"
-    "@ember-decorators/service" "^5.1.2"
+    "@ember-decorators/component" "^5.1.4"
+    "@ember-decorators/controller" "^5.1.4"
+    "@ember-decorators/data" "^5.1.4"
+    "@ember-decorators/object" "^5.1.4"
+    "@ember-decorators/service" "^5.1.4"
     ember-cli-babel "^7.1.3"
     semver "^5.5.0"
 


### PR DESCRIPTION
* Renamed `runJob()` to `run()`
* Changed the function's signature to match those of functions of the `Ember.run` family, i.e. supports not just a simple function, but also `target`, arbitrary arguments and string-based method lookup
* Removed imperative `.start()`/`.stop()` methods
* better test coverage

/cc @lolmaus 