### PR TITLE
Fix hanging promise when routeWillChange event is triggered twice

### DIFF
--- a/addon/services/loading.ts
+++ b/addon/services/loading.ts
@@ -72,6 +72,9 @@ export default class LoadingService extends Service {
   @action
   _routeWillChange() {
     let deferred = defer();
+    if (this._routerTransitionDeferred) {
+      this._routerTransitionDeferred.resolve();
+    }
     this.set('_routerTransitionDeferred', deferred);
     this.run(() => deferred.promise);
   }
@@ -80,6 +83,7 @@ export default class LoadingService extends Service {
   _routeDidChange() {
     if (this._routerTransitionDeferred) {
       this._routerTransitionDeferred.resolve();
+      this.set('_routerTransitionDeferred', undefined);
     }
   }
 

--- a/tests/unit/services/loading-test.ts
+++ b/tests/unit/services/loading-test.ts
@@ -232,6 +232,29 @@ module('Unit | Service | loading', function(hooks) {
       assert.notOk(service.get('showLoading'));
     });
 
+    test('multiple route transition events are handled correctly', async function(assert) {
+      let service: LoadingService = this.owner.lookup('service:loading');
+      let router = this.owner.lookup('service:router');
+
+      assert.notOk(service.get('isLoading'));
+      assert.notOk(service.get('showLoading'));
+
+      router.trigger('routeWillChange');
+      await settled();
+      assert.ok(service.get('isLoading'));
+      assert.ok(service.get('showLoading'));
+
+      router.trigger('routeWillChange');
+      await settled();
+      assert.ok(service.get('isLoading'));
+      assert.ok(service.get('showLoading'));
+
+      router.trigger('routeDidChange');
+      await settled();
+      assert.notOk(service.get('isLoading'));
+      assert.notOk(service.get('showLoading'));
+    });
+
     test('supports postDelay', async function(assert) {
       let Service: typeof LoadingService = this.owner.factoryFor('service:loading');
       let service: LoadingService = Service.create({


### PR DESCRIPTION
The `_runJob` concurrency task would stay active if a previous deferred promise is not resolved but simply overridden, by receiving routeWillChange twice before routeDidChange

/cc @lolmaus 